### PR TITLE
updating the UI display of 'clinical note' to be what Steve requested…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.3.2'
+		classpath 'com.android.tools.build:gradle:2.3.3'
 		classpath 'me.tatarka:gradle-retrolambda:3.2.3'
 	}
 }

--- a/openmrs-client/src/main/res/values/strings.xml
+++ b/openmrs-client/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
 	<string name="no_visit_images">No Visit Images</string>
 	<string name="primary_diagnosis_label">Primary Diagnosis</string>
 	<string name="secondary_diagnosis_label">Secondary Diagnosis</string>
-	<string name="clinical_notes_label">Clinical note</string>
+	<string name="clinical_notes_label">Patient Problem Summary</string>
 	<string name="no_vitals">No vitals recorded for this visit</string>
 	<string name="no_visit_tasks">No tasks for this visit</string>
 	<string name="add_diagnosis">Enter Diagnosis</string>
@@ -365,7 +365,7 @@
 	<string name="visit_note_changes_pending_title">Pending Changes</string>
 	<string name="visit_note_changes_pending_message">You have unsaved changes on the visit note. Leaving this
 		screen while discard your changes</string>
-	<string name="no_clinical_note">No Clinical Note</string>
+	<string name="no_clinical_note">No Patient Problem Summary</string>
 	<string name="civil_status">Civil Status</string>
 	<string name="kin_relationship">Kin Relationship</string>
 	<string name="change_server_url">Change Server URL</string>


### PR DESCRIPTION
…; this was only done at the front end because clinical notes are used by OpenMRS - so, we only change what the UI displays instead of the entire variable names throughout the code to minimize confusion