### PR TITLE
Added test method to debug search patient exception (WIP)

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/data/db/impl/PatientDbService.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/data/db/impl/PatientDbService.java
@@ -95,7 +95,7 @@ public class PatientDbService extends BaseDbService<Patient> implements DbServic
 
 	private SQLOperator findByNameFragment(@NonNull String name) {
 		checkNotNull(name);
-
+		name = name.trim();
 		if (!name.startsWith("%")) {
 			name = "%" + name;
 		}

--- a/openmrs-client/src/main/java/org/openmrs/mobile/data/db/impl/PatientDbService.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/data/db/impl/PatientDbService.java
@@ -4,8 +4,10 @@ import android.support.annotation.NonNull;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.Method;
+import com.raizlabs.android.dbflow.sql.language.OperatorGroup;
 import com.raizlabs.android.dbflow.sql.language.SQLOperator;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
+import com.raizlabs.android.dbflow.sql.language.property.Property;
 import com.raizlabs.android.dbflow.structure.ModelAdapter;
 
 import org.openmrs.mobile.data.PagingInfo;
@@ -100,17 +102,14 @@ public class PatientDbService extends BaseDbService<Patient> implements DbServic
 		if (!name.endsWith("%")) {
 			name = name + "%";
 		}
-
 		return Patient_Table.person_uuid.in(
-				SQLite.select(PersonName_Table.person_uuid)
-						.from(PersonName.class)
-						.where(Method.group_concat(
-								PersonName_Table.givenName,
-								PersonName_Table.middleName,
-								PersonName_Table.familyName)
-							.like(name)
-						)
-		);
+
+				SQLite.select(PersonName_Table.person_uuid).from(PersonName.class).
+						where(OperatorGroup.clause()
+								.or(PersonName_Table.givenName.like(name))
+								.or(PersonName_Table.middleName.like(name))
+								.or(PersonName_Table.familyName.like(name))
+						));
 	}
 
 	private SQLOperator findById(String id) {

--- a/openmrs-client/src/test/java/org/openmrs/mobile/data/db/RepositoryTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/data/db/RepositoryTest.java
@@ -2,6 +2,7 @@ package org.openmrs.mobile.data.db;
 
 import com.raizlabs.android.dbflow.config.FlowManager;
 import com.raizlabs.android.dbflow.sql.language.Method;
+import com.raizlabs.android.dbflow.sql.language.OperatorGroup;
 import com.raizlabs.android.dbflow.sql.language.SQLite;
 
 import org.junit.After;
@@ -296,8 +297,12 @@ public class RepositoryTest {
 		//retreive patient "Mika"
 		patients = repository.query(patientTable,
 		Patient_Table.person_uuid.in(
-				SQLite.select(PersonName_Table.person_uuid).from(PersonName.class)
-						.where(PersonName_Table.givenName.like("Mika"))));
+				SQLite.select(PersonName_Table.person_uuid).from(PersonName.class).
+						where(OperatorGroup.clause()
+						.or(PersonName_Table.givenName.like("Mika"))
+						.or(PersonName_Table.middleName.like("Mika"))
+						.or(PersonName_Table.familyName.like("Mika"))
+						)));
 		Assert.assertNotNull(patients);
 		Assert.assertEquals(1,patients.size());
 		Assert.assertEquals("Mika",patients.get(0).getPerson().getName().getGivenName());

--- a/openmrs-client/src/test/java/org/openmrs/mobile/data/db/RepositoryTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/data/db/RepositoryTest.java
@@ -274,37 +274,4 @@ public class RepositoryTest {
 		Assert.assertNotNull(dbPerson);
 		ModelAsserters.PERSON.assertModel(person, dbPerson);
 	}
-
-	@Test
-	public void testSearchPatient(){
-		PatientDbService patientDbService = Mockito.mock(PatientDbService.class);
-//		Repository repositoryTest = Mockito.mock(RepositoryImpl.class);
-		List<Patient> patients;
-
-		Patient p1 = ModelGenerators.PATIENT.generate(true);
-		Patient p2 = ModelGenerators.PATIENT.generate(true);
-		Patient p3 = ModelGenerators.PATIENT.generate(true);
-
-		p1.getPerson().getName().setGivenName("Mso");
-		p2.getPerson().getName().setGivenName("Mika");
-		p3.getPerson().getName().setGivenName("Mwas");
-
-		//save the records
-		repository.save(patientTable,p1);
-		repository.save(patientTable,p2);
-		repository.save(patientTable,p3);
-
-		//retreive patient "Mika"
-		patients = repository.query(patientTable,
-		Patient_Table.person_uuid.in(
-				SQLite.select(PersonName_Table.person_uuid).from(PersonName.class).
-						where(OperatorGroup.clause()
-						.or(PersonName_Table.givenName.like("Mika"))
-						.or(PersonName_Table.middleName.like("Mika"))
-						.or(PersonName_Table.familyName.like("Mika"))
-						)));
-		Assert.assertNotNull(patients);
-		Assert.assertEquals(1,patients.size());
-		Assert.assertEquals("Mika",patients.get(0).getPerson().getName().getGivenName());
-	}
 }

--- a/openmrs-client/src/test/java/org/openmrs/mobile/data/db/RepositoryTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/data/db/RepositoryTest.java
@@ -296,16 +296,8 @@ public class RepositoryTest {
 		//retreive patient "Mika"
 		patients = repository.query(patientTable,
 		Patient_Table.person_uuid.in(
-				SQLite.select(PersonName_Table.person_uuid)
-						.from(PersonName.class)
-						.where(Method.group_concat(
-								PersonName_Table.givenName,
-								PersonName_Table.middleName,
-								PersonName_Table.familyName
-								)
-										.like("Mika")
-						)));
-
+				SQLite.select(PersonName_Table.person_uuid).from(PersonName.class)
+						.where(PersonName_Table.givenName.like("Mika"))));
 		Assert.assertNotNull(patients);
 		Assert.assertEquals(1,patients.size());
 		Assert.assertEquals("Mika",patients.get(0).getPerson().getName().getGivenName());

--- a/openmrs-client/src/test/java/org/openmrs/mobile/data/db/impl/PatientDbServiceTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/data/db/impl/PatientDbServiceTest.java
@@ -49,27 +49,34 @@ public class PatientDbServiceTest extends BaseAuditableDbServiceTest<Patient> {
 
 	@Test
 	public void getByName_shouldSearchByNameWithFullWildcard() throws Exception {
-		repository = mock(RepositoryImpl.class);
+		repository = new RepositoryImpl();
 		PatientDbService patientDbService = new PatientDbService(repository);
 		List<Patient> patientSearchResults;
 
 		Patient p1 = ModelGenerators.PATIENT.generate(true);
 		Patient p2 = ModelGenerators.PATIENT.generate(true);
 		Patient p3 = ModelGenerators.PATIENT.generate(true);
+		Patient p4 = ModelGenerators.PATIENT.generate(true);
 
 		p1.getPerson().getName().setMiddleName("Mishi");
 		p2.getPerson().getName().setGivenName("Mika");
 		p3.getPerson().getName().setFamilyName("Mistari");
+		p4.getPerson().getName().setGivenName("Rabashmisna");
 
 		repository.save(patientTable,p1);
 		repository.save(patientTable,p2);
 		repository.save(patientTable,p3);
+		repository.save(patientTable,p4);
 
-		Assert.assertNotNull(p3);
-		patientSearchResults = patientDbService.getByName("Mishi", null, null);
+		//get all names with fragment 'mis' in them
+		patientSearchResults = patientDbService.getByName("Mis", null, null);
+
 		Assert.assertNotNull(patientSearchResults);
+		Assert.assertFalse(patientSearchResults.isEmpty());
 		Assert.assertEquals(3, patientSearchResults.size());
-		Assert.assertEquals("Mishi", patientSearchResults.get(0).getPerson().getName().getGivenName());
+		Assert.assertFalse(patientSearchResults.contains(p2)); //results must NOT have "Mika"
+		Assert.assertEquals("Mistari", patientSearchResults.get(1).getPerson().getName().getFamilyName());
+		Assert.assertEquals("Rabashmisna", patientSearchResults.get(2).getPerson().getName().getGivenName());
 	}
 
 	@Test

--- a/openmrs-client/src/test/java/org/openmrs/mobile/data/db/impl/PatientDbServiceTest.java
+++ b/openmrs-client/src/test/java/org/openmrs/mobile/data/db/impl/PatientDbServiceTest.java
@@ -1,13 +1,37 @@
 package org.openmrs.mobile.data.db.impl;
 
+import com.raizlabs.android.dbflow.config.FlowManager;
+import com.raizlabs.android.dbflow.sql.language.OperatorGroup;
+import com.raizlabs.android.dbflow.sql.language.SQLite;
+
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
 import org.openmrs.mobile.data.ModelAsserters;
 import org.openmrs.mobile.data.ModelGenerators;
 import org.openmrs.mobile.data.db.BaseAuditableDbServiceTest;
 import org.openmrs.mobile.data.db.BaseDbService;
+import org.openmrs.mobile.data.db.Repository;
 import org.openmrs.mobile.models.Patient;
+import org.openmrs.mobile.models.Patient_Table;
+import org.openmrs.mobile.models.PersonName;
+import org.openmrs.mobile.models.PersonName_Table;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 public class PatientDbServiceTest extends BaseAuditableDbServiceTest<Patient> {
+		@InjectMocks private Repository repository;
+	private Patient_Table patientTable;
+
+	@Before
+	public void beforeTests(){
+		patientTable = (Patient_Table) FlowManager.getInstanceAdapter(Patient.class);
+	}
+
 	@Override
 	protected BaseDbService<Patient> getDbService() {
 		return new PatientDbService(new RepositoryImpl());
@@ -25,7 +49,27 @@ public class PatientDbServiceTest extends BaseAuditableDbServiceTest<Patient> {
 
 	@Test
 	public void getByName_shouldSearchByNameWithFullWildcard() throws Exception {
+		repository = mock(RepositoryImpl.class);
+		PatientDbService patientDbService = new PatientDbService(repository);
+		List<Patient> patientSearchResults;
 
+		Patient p1 = ModelGenerators.PATIENT.generate(true);
+		Patient p2 = ModelGenerators.PATIENT.generate(true);
+		Patient p3 = ModelGenerators.PATIENT.generate(true);
+
+		p1.getPerson().getName().setMiddleName("Mishi");
+		p2.getPerson().getName().setGivenName("Mika");
+		p3.getPerson().getName().setFamilyName("Mistari");
+
+		repository.save(patientTable,p1);
+		repository.save(patientTable,p2);
+		repository.save(patientTable,p3);
+
+		Assert.assertNotNull(p3);
+		patientSearchResults = patientDbService.getByName("Mishi", null, null);
+		Assert.assertNotNull(patientSearchResults);
+		Assert.assertEquals(3, patientSearchResults.size());
+		Assert.assertEquals("Mishi", patientSearchResults.get(0).getPerson().getName().getGivenName());
 	}
 
 	@Test
@@ -117,4 +161,5 @@ public class PatientDbServiceTest extends BaseAuditableDbServiceTest<Patient> {
 	public void getByNameOrIdentifier_shouldThrowExceptionWhenNameOrIdIsNull() throws Exception {
 
 	}
+
 }


### PR DESCRIPTION
The test method fails with the same exception:  

`Caused` by: java.util.concurrent.ExecutionException: com.almworks.sqlite4java.SQLiteException: [1] DB[7] prepare() SELECT * FROM `Patient` WHERE `person_uuid` IN (SELECT `person_uuid` FROM `PersonName` WHERE GROUP_CONCAT(`givenName`, `middleName`, `familyName`) LIKE 'Mika' ) [wrong number of arguments to function GROUP_CONCAT()]`