### PR TITLE
Bugfix/andr 290 - App crash during initial sync when UI is blocked

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/loginsync/LoginSyncFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/loginsync/LoginSyncFragment.java
@@ -50,6 +50,19 @@ public class LoginSyncFragment extends ACBaseFragment<LoginSyncContract.Presente
 		super.onStop();
 	}
 
+	@Override
+	public void onPause(){
+		super.onPause();
+		mPresenter.stopMeasuringConnectivity();
+	}
+
+	@Override
+	public void onResume(){
+		mPresenter.startMeasuringConnectivity();
+		super.onResume();
+
+	}
+
 	private void initViewFields() {
 		pushProgressBar = (ProgressBar) rootView.findViewById(R.id.pushProgressBar);
 		pushProgressText = (TextView) rootView.findViewById(R.id.pushProgressText);

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/loginsync/LoginSyncPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/loginsync/LoginSyncPresenter.java
@@ -30,6 +30,7 @@ public class LoginSyncPresenter extends BasePresenter implements LoginSyncContra
 	private boolean arePushing = false;
 	private boolean arePulling = false;
 	private boolean trimHasBeenCompleted = false;
+	private TimerTask measureConnectivityTimerTask;
 
 	private final int DELAY = 500;
 	private final double SMOOTHING_FACTOR = 0.005;
@@ -182,21 +183,23 @@ public class LoginSyncPresenter extends BasePresenter implements LoginSyncContra
 	public void startMeasuringConnectivity() {
 		averageNetworkSpeed = null;
 		networkConnectionIsFast = null;
-		if (networkConnectivityCheckTimer == null) {
-			networkConnectivityCheckTimer = new Timer();
-		}
-		networkConnectivityCheckTimer.schedule(new TimerTask() {
+		measureConnectivityTimerTask = new TimerTask() {
 			@Override
 			public void run() {
 				calculateNewAverageNetworkSpeed();
 				Boolean previousConnectionSpeedIsFast = networkConnectionIsFast;
 				determineNetworkConnectionSpeed();
-				if (previousConnectionSpeedIsFast == null || (previousConnectionSpeedIsFast && !networkConnectionIsFast)
+				if (previousConnectionSpeedIsFast == null
+						|| (previousConnectionSpeedIsFast && !networkConnectionIsFast)
 						|| (!previousConnectionSpeedIsFast && networkConnectionIsFast)) {
 					view.runOnUIThread(() -> notifyViewToUpdateConnectionDisplay());
 				}
 			}
-		}, DELAY, DELAY);
+		};
+		if (networkConnectivityCheckTimer == null) {
+			networkConnectivityCheckTimer = new Timer();
+		}
+		networkConnectivityCheckTimer.schedule(measureConnectivityTimerTask, DELAY, DELAY);
 	}
 
 	private void determineNetworkConnectionSpeed() {
@@ -240,7 +243,7 @@ public class LoginSyncPresenter extends BasePresenter implements LoginSyncContra
 	}
 
 	public void stopMeasuringConnectivity() {
-		networkConnectivityCheckTimer.cancel();
+		measureConnectivityTimerTask.cancel();
 	}
 
 	private void calculateNewAverageNetworkSpeed() {


### PR DESCRIPTION
Somewhat fixes app crashes that result from onPause being called while initial sync is taking place. However, crashes resulting from onStart() being called during initial sync are not yet resolved