### PR TITLE
andr-352 - Patients can't be edited and Visits can't be started

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardFragment.java
@@ -182,7 +182,8 @@ public class PatientDashboardFragment extends BaseDiagnosisFragment<PatientDashb
 	@Override
 	public void patientContacts(Patient patient) {
 		this.patient = patient;
-		openMRS.setPatientUuid(patient.getPerson().getUuid());
+		patientUuid = patient.getPerson().getUuid();
+		openMRS.setPatientUuid(patientUuid);
 	}
 
 	@Override
@@ -301,7 +302,8 @@ public class PatientDashboardFragment extends BaseDiagnosisFragment<PatientDashb
 	public void onDestroy() {
 		super.onDestroy();
 
-		openMRS.setPatientUuid(ApplicationConstants.EMPTY_STRING);
+		patientUuid = ApplicationConstants.EMPTY_STRING;
+		openMRS.setPatientUuid(patientUuid);
 	}
 
 	@Override


### PR DESCRIPTION
adding back in setting of patient UUID to make sure starting a visit or editting a patient is possible