### PR TITLE
andr-355 - Spinning Icon not disappearing from Visit Image Tab 

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/visit/visitphoto/VisitPhotoPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/visit/visitphoto/VisitPhotoPresenter.java
@@ -95,6 +95,7 @@ public class VisitPhotoPresenter extends BaseVisitPresenter implements VisitCont
 		if (observations == null || observations.isEmpty()) {
 			visitPhotoView.showTabSpinner(false);
 			visitPhotoView.updateVisitImageMetadata(visitPhotos);
+			removeRefreshIndicatorIfAllCallsComplete();
 			return;
 		}
 


### PR DESCRIPTION
made the indicator disappear if no images need to be loaded