### PR TITLE
andr-350 - Wrong message on Patient List's results 

### DIFF
--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/BaseDiagnosisPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/BaseDiagnosisPresenter.java
@@ -30,8 +30,8 @@ public class BaseDiagnosisPresenter {
 	private ConceptDataService conceptDataService;
 	private ObsDataService obsDataService;
 	private VisitNoteDataService visitNoteDataService;
-	private int page = PagingInfo.DEFAULT.getPage();
-	private int limit = PagingInfo.DEFAULT.getLimit() * 2;
+	private int page = PagingInfo.DEFAULT.getInstance().getPage();
+	private int limit = PagingInfo.DEFAULT.getInstance().getLimit() * 2;
 	private List<String> obsUuids = new ArrayList<>();
 	private DataAccessComponent dataAccess;
 	private Timer diagnosisTimer;

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/addeditpatient/AddEditPatientPresenter.java
@@ -263,7 +263,7 @@ public class AddEditPatientPresenter extends BasePresenter implements AddEditPat
 	}
 
 	public void findSimilarPatients(Patient patient) {
-		PagingInfo pagingInfo = PagingInfo.DEFAULT;
+		PagingInfo pagingInfo = PagingInfo.DEFAULT.getInstance();
 		DataService.GetCallback<List<Patient>> callback = new DataService.GetCallback<List<Patient>>() {
 			@Override
 			public void onCompleted(List<Patient> patients) {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/dialog/PatientListSyncSelectionDialogPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/dialog/PatientListSyncSelectionDialogPresenter.java
@@ -120,7 +120,7 @@ public class PatientListSyncSelectionDialogPresenter implements PatientListSyncS
 	}
 
 	private void getPatientLists() {
-		patientListDataService.getAll(null, PagingInfo.ALL,
+		patientListDataService.getAll(null, PagingInfo.ALL.getInstance(),
 				new DataService.GetCallback<List<PatientList>>() {
 					@Override
 					public void onCompleted(List<PatientList> entities) {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/findpatientrecord/FindPatientRecordPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/findpatientrecord/FindPatientRecordPresenter.java
@@ -33,7 +33,7 @@ public class FindPatientRecordPresenter extends BasePresenter implements FindPat
 
 	@NonNull
 	private FindPatientRecordContract.View findPatientView;
-	private int page = PagingInfo.DEFAULT.getPage();
+	private int page = PagingInfo.DEFAULT.getInstance().getPage();
 	private PatientDataService patientDataService;
 	private boolean loading;
 
@@ -62,7 +62,7 @@ public class FindPatientRecordPresenter extends BasePresenter implements FindPat
 
 	public void findPatient(String query) {
 		findPatientView.setProgressBarVisibility(true);
-		PagingInfo pagingInfo = PagingInfo.ALL;
+		PagingInfo pagingInfo = PagingInfo.ALL.getInstance();
 		DataService.GetCallback<List<Patient>> getMultipleCallback = new DataService.GetCallback<List<Patient>>() {
 			@Override
 			public void onCompleted(List<Patient> patients) {
@@ -95,7 +95,7 @@ public class FindPatientRecordPresenter extends BasePresenter implements FindPat
 	public void getLastViewed() {
 		findPatientView.setProgressBarVisibility(true);
 		setLoading(true);
-		PagingInfo pagingInfo = PagingInfo.DEFAULT;
+		PagingInfo pagingInfo = PagingInfo.DEFAULT.getInstance();
 		patientDataService.getLastViewed(ApplicationConstants.EMPTY_STRING, QueryOptions.FULL_REP, pagingInfo,
 				new DataService.GetCallback<List<Patient>>() {
 					@Override

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardFragment.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardFragment.java
@@ -81,7 +81,9 @@ public class PatientDashboardFragment extends BaseDiagnosisFragment<PatientDashb
 	public void onDestroyView() {
 		super.onDestroyView();
 		patientVisitsRecyclerView.removeOnScrollListener(patientVisitsOnScrollListener);
-		patientVisitsRecyclerAdapter.destroy();
+		if (patientVisitsRecyclerAdapter != null) {
+			patientVisitsRecyclerAdapter.destroy();
+		}
 	}
 
 	@Override

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/patientdashboard/PatientDashboardPresenter.java
@@ -44,7 +44,7 @@ public class PatientDashboardPresenter extends BasePresenter implements PatientD
 
 	private NetworkUtils networkUtils;
 
-	private final int INITIAL_PAGING_INDEX = PagingInfo.DEFAULT.getPage();
+	private final int INITIAL_PAGING_INDEX = PagingInfo.DEFAULT.getInstance().getPage();
 
 	private PatientDashboardContract.View patientDashboardView;
 	private PatientDataService patientDataService;

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/visit/detail/VisitDetailsPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/visit/detail/VisitDetailsPresenter.java
@@ -123,7 +123,7 @@ public class VisitDetailsPresenter extends BaseVisitPresenter implements VisitCo
 				.build();
 
 		visitAttributeTypeDataService
-				.getAll(options, PagingInfo.ALL,
+				.getAll(options, PagingInfo.ALL.getInstance(),
 						new DataService.GetCallback<List<VisitAttributeType>>() {
 							@Override
 							public void onCompleted(List<VisitAttributeType> entities) {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/activities/visit/visittasks/VisitTasksPresenter.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/activities/visit/visittasks/VisitTasksPresenter.java
@@ -65,7 +65,7 @@ public class VisitTasksPresenter extends BaseVisitPresenter implements VisitCont
 		if (!forceRefresh) {
 			visitTasksView.showTabSpinner(true);
 		}
-		PagingInfo pagingInfo = PagingInfo.ALL;
+		PagingInfo pagingInfo = PagingInfo.ALL.getInstance();
 		DataService.GetCallback<List<VisitPredefinedTask>> callback = new DataService
 				.GetCallback<List<VisitPredefinedTask>>() {
 			@Override
@@ -102,7 +102,7 @@ public class VisitTasksPresenter extends BaseVisitPresenter implements VisitCont
 		}
 		final QueryOptions options = optionsTemp;
 
-		PagingInfo pagingInfo = PagingInfo.DEFAULT;
+		PagingInfo pagingInfo = PagingInfo.DEFAULT.getInstance();
 		// get open tasks
 		visitTaskDataService.getAll("OPEN", patientUUID, visitUuid, options,
 				pagingInfo,

--- a/openmrs-client/src/main/java/org/openmrs/mobile/data/PagingInfo.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/data/PagingInfo.java
@@ -10,12 +10,22 @@ public class PagingInfo {
 	/**
 	 * Sets the page size to 10,000 so that all results will be included and the server-defined default limit won't be used.
 	 */
-	public static final PagingInfo ALL = new PagingInfo(1, 10000);
+	public static class ALL {
+
+		public static PagingInfo getInstance() {
+			return new PagingInfo(1, 10000);
+		}
+	}
 
 	/**
 	 * Sets the page size to 10, matching the default page size for most entities.
 	 */
-	public static final PagingInfo DEFAULT = new PagingInfo(1, 10);
+	public static class DEFAULT {
+
+		public static PagingInfo getInstance() {
+			return new PagingInfo(1, 10);
+		}
+	}
 
 	private int page;
 	private int pageSize;
@@ -106,5 +116,14 @@ public class PagingInfo {
 
 	public Boolean hasMoreResults() {
 		return (page * pageSize) < totalRecordCount;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object.getClass() == PagingInfo.class) {
+			PagingInfo pagingInfo = (PagingInfo) object;
+			return pagingInfo.getPage() == this.getPage() && pagingInfo.getLimit() == this.getLimit();
+		}
+		return false;
 	}
 }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/data/impl/PatientListContextDataService.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/data/impl/PatientListContextDataService.java
@@ -46,8 +46,12 @@ public class PatientListContextDataService
 				(patientListContextsFromServer) -> {
 					dbService.saveAll(patientListContextsFromServer);
 
-					databaseHelper.diffDelete(PatientListContext.class,
-							PatientListContext_Table.patientList_uuid.eq(patientListUuid), patientListContextsFromServer);
+					// Only trim from the DB if we've fetched all the data
+					if (pagingInfo == null || pagingInfo.equals(PagingInfo.ALL.getInstance())) {
+						databaseHelper.diffDelete(PatientListContext.class,
+								PatientListContext_Table.patientList_uuid.eq(patientListUuid),
+								patientListContextsFromServer);
+					}
 				});
 	}
 }

--- a/openmrs-client/src/main/java/org/openmrs/mobile/data/rest/impl/PatientListContextRestServiceImpl.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/data/rest/impl/PatientListContextRestServiceImpl.java
@@ -31,7 +31,7 @@ public class PatientListContextRestServiceImpl extends BaseRestService<PatientLi
 	public Call<Results<PatientListContext>> getListPatients(String patientListUuid, QueryOptions options, PagingInfo pagingInfo) {
 		// If no paging is specified then override the server defaults to return all records
 		if (pagingInfo == null) {
-			pagingInfo = PagingInfo.ALL;
+			pagingInfo = PagingInfo.ALL.getInstance();
 		}
 		String representation = QueryOptions.getRepresentation(options);
 		if (options == null) {

--- a/openmrs-client/src/main/java/org/openmrs/mobile/data/sync/AdaptiveSubscriptionProvider.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/data/sync/AdaptiveSubscriptionProvider.java
@@ -256,7 +256,7 @@ public abstract class AdaptiveSubscriptionProvider<E extends BaseOpenmrsAuditabl
 	 * @return The entities
 	 */
 	protected List<E> getAllRest() {
-		return RestHelper.getCallListValue(restService.getAll(QueryOptions.FULL_REP, PagingInfo.ALL));
+		return RestHelper.getCallListValue(restService.getAll(QueryOptions.FULL_REP, PagingInfo.ALL.getInstance()));
 	}
 
 	/**

--- a/openmrs-client/src/main/java/org/openmrs/mobile/data/sync/impl/VisitPullProvider.java
+++ b/openmrs-client/src/main/java/org/openmrs/mobile/data/sync/impl/VisitPullProvider.java
@@ -104,7 +104,7 @@ public class VisitPullProvider {
 		// Get record info for patient visits
 		List<RecordInfo> visitInfo = RestHelper.getCallListValue(
 				visitRestService.getRecordInfoByPatient(patientRecord.getUuid(),
-						new QueryOptions.Builder().includeInactive(true).build(), PagingInfo.ALL));
+						new QueryOptions.Builder().includeInactive(true).build(), PagingInfo.ALL.getInstance()));
 
 		// Delete any missing visits
 		databaseHelper.diffDelete(Visit.class, Visit_Table.patient_uuid.eq(patientRecord.getUuid()), visitInfo);
@@ -142,7 +142,7 @@ public class VisitPullProvider {
 
 		for (RecordInfo visitRecord : visitInfo) {
 			List<RecordInfo> visitTasks = RestHelper.getCallListValue(visitTaskRestService.getRecordInfoByVisit
-					(visitRecord.getUuid(), null, PagingInfo.ALL));
+					(visitRecord.getUuid(), null, PagingInfo.ALL.getInstance()));
 
 			Visit visit = visitDbService.getByUuid(visitRecord.getUuid(), null);
 
@@ -237,7 +237,7 @@ public class VisitPullProvider {
 		for (RecordInfo visitRecord : visitInfo) {
 			// Get record info for visit encounters
 			List<RecordInfo> encounterInfo = RestHelper.getCallListValue(
-					encounterRestService.getRecordInfoByVisit(visitRecord.getUuid(), null, PagingInfo.ALL));
+					encounterRestService.getRecordInfoByVisit(visitRecord.getUuid(), null, PagingInfo.ALL.getInstance()));
 
 			// Delete any missing encounters
 			databaseHelper.diffDelete(Encounter.class, Encounter_Table.visit_uuid.eq(visitRecord.getUuid()), encounterInfo);


### PR DESCRIPTION
fixing a problem where the patient list results weren't displayed correctly because of improper use of paging info and how data is deleted when patient contexts refreshed