### PR TITLE
Gradle Build Tools Update

### DIFF
--- a/openmrs-client/build.gradle
+++ b/openmrs-client/build.gradle
@@ -35,7 +35,6 @@ if (keystorePropertiesFile.exists()) {
 
 android {
 	compileSdkVersion rootProject.ext.compileSdkVersion
-	buildToolsVersion '27.0.3'
 	useLibrary 'org.apache.http.legacy'
 
 	defaultConfig {


### PR DESCRIPTION
removing build tools version because it is now defaulted based on the plugin as of Android plugin for Gradle 3.0.0